### PR TITLE
Nominate Orie Steele as a go-cose maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -25,7 +25,8 @@
       "sergeitrofimov",
       "stevelasker",
       "henkbirkholz",
-      "shizhMSFT"
+      "shizhMSFT",
+      "OR13"
     ]
 
 [people]
@@ -66,3 +67,8 @@
     Name = "Shiwei Zhang"
     Email = "Shiwei.Zhang@microsoft.com"
     GitHub = "shizhMSFT"
+
+    [people.OR13]
+    Name = "Orie Steele"
+    Email = "orie@transmute.industries"
+    GitHub = "OR13"


### PR DESCRIPTION
Orie has 
-	attended bi-weekly go-cose calls continually providing great insight. 
-	[provided pr feedback](https://github.com/veraison/go-cose/pulls?q=OR13) 
-	[provided issue feedback](https://github.com/veraison/go-cose/issues?q=OR13)
-	been active in IETF groups

